### PR TITLE
Fix wrong data type with saving temporary files for Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 *.pyc
+
+# Eclipse
+.project
+.pydevproject
+.settings

--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ pyfzf
 Requirements
 ------------
 
-* Python 2.6+
+* Python 2.6+, 3.0+
 * [fzf](https://github.com/junegunn/fzf)
 
 *Note*: fzf must be installed and available on PATH.
 
 Installation
 ------------
-	pip install pyfzf
+    pip install pyfzf
 
 Usage
 -----
@@ -35,7 +35,11 @@ Simply pass a list of options to the prompt function to invoke fzf.
 
 Pass additional arguments to fzf as a second argument
 
-	>>> fzf.prompt(range(0,10), '--multi --cycle')
+    >>> fzf.prompt(range(0,10), '--multi --cycle')
+
+Pass multiword arguments to fzf
+
+    >>> fzf.prompt(range(0,10), '--header="Custom header" --query="^prefix suffix$"')
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ pyfzf
 
 ![](https://img.shields.io/badge/license-MIT-green.svg?style=flat)
 ![https://pypi.python.org/pypi/pyfzf](https://img.shields.io/pypi/dm/pyfzf.svg?style=flat)
-   
+
 ##### A python wrapper for *junegunn*'s awesome [fzf](https://github.com/junegunn/fzf).
 
 ![](https://raw.githubusercontent.com/nk412/pyfzf/master/pyfzf.gif)
@@ -23,6 +23,10 @@ Installation
 Usage
 -----
     >>> from pyfzf import FzfPrompt
+    >>> fzf = FzfPrompt()
+
+For Python 3+
+    >>> from pyfzf.pyfzf import FzfPrompt
     >>> fzf = FzfPrompt()
 
 Simply pass a list of options to the prompt function to invoke fzf.

--- a/pyfzf/filefzf.sh
+++ b/pyfzf/filefzf.sh
@@ -15,5 +15,5 @@ output_file=$1
 shift
 options="$@"
 
-cat $input_file | fzf $options > $output_file
+cat $input_file | eval fzf $options > $output_file
 exit $?

--- a/pyfzf/pyfzf.py
+++ b/pyfzf/pyfzf.py
@@ -49,8 +49,8 @@ class FzfPrompt:
                 input_file.write(choices_str)
                 input_file.flush()
 
-				# Invoke fzf externally and write to output file
-                self.sh['-c', CURRENT_DIR + "/filefzf.sh {0} {1} {2}".format(input_file.name, output_file.name,
+                # Invoke fzf externally and write to output file
+                self.sh['-c', CURRENT_DIR + "/filefzf.sh {0} {1} {2!r}".format(input_file.name, output_file.name,
                                                                              fzf_options)] & FG
 
                 # get selected options

--- a/pyfzf/pyfzf.py
+++ b/pyfzf/pyfzf.py
@@ -43,8 +43,8 @@ class FzfPrompt:
         # convert lists to strings [ 1, 2, 3 ] => "1\n2\n3"
         choices_str = '\n'.join(map(str, choices))
         selection = []
-        with tempfile.NamedTemporaryFile() as input_file:
-            with tempfile.NamedTemporaryFile() as output_file:
+        with tempfile.NamedTemporaryFile(mode="w+") as input_file:
+            with tempfile.NamedTemporaryFile(mode="w+") as output_file:
                 # Create an temp file with list entries as lines
                 input_file.write(choices_str)
                 input_file.flush()


### PR DESCRIPTION
For Python 3 there is strict distinct between text and binary data so
all temporary files should be open with "w+" not "w+b" (default option).