### PR TITLE
Clarify README for fzf environment variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ You can pass additional arguments to fzf as a second argument
 
     >>> fzf.prompt(range(0,10), '--multi --cycle')
 
+Note that `pyfzf` respects all [`fzf` environment variables](https://github.com/junegunn/fzf#environment-variables).
+For example, if you include the following line in your shell's rc file
+
+    FZF_DEFAULT_OPTS="--multi --cycle"
+
+then the above Python REPL line can be simplified to
+
+    >>> fzf.prompt(range(0,10))
+
 Input items are written to a temporary file which is then passed to fzf.
 The items are delimited with `\n` by default, you can also change the delimiter
 (useful for multiline items)


### PR DESCRIPTION
`fzf` is extremely customizable using environment variables. Because your project simply calls `fzf` in the background, your package can also benefit from this customizability.

Unfortunately, this fact about `pyfzf` must be discovered via trial and error or else by just reading the source code. Much better for the user would be to simply make it explicit in the README.

Hence this PR simply updates the README to clarify this fact about `fzf` environment variables, including a simple example.